### PR TITLE
Added logic to use the plural or singular form of the time (eg. day(s) o...

### DIFF
--- a/jquery.countdown.js
+++ b/jquery.countdown.js
@@ -83,6 +83,13 @@ and GPL-3.0 (http://opensource.org/licenses/GPL-3.0) licenses.
         _this.options.date = newDate;
         return _this;
       };
+      this.isPlural = function(number, single_string) {
+        if(number > 1) {
+          return single_string + "s";
+        } else {
+          return single_string;
+        }
+      };
       this.render = function() {
         _this.options.render.apply(_this, [getDateData(_this.options.date)]);
         return _this;
@@ -115,7 +122,11 @@ and GPL-3.0 (http://opensource.org/licenses/GPL-3.0) licenses.
       refresh: 1000,
       onEnd: $.noop,
       render: function(date) {
-        return $(this.el).html("" + date.years + " years, " + date.days + " days, " + (this.leadingZeros(date.hours)) + " hours, " + (this.leadingZeros(date.min)) + " min and " + (this.leadingZeros(date.sec)) + " sec");
+        var days = this.isPlural(date.days, "day");
+        var years = this.isPlural(date.years, "year");
+        var min = this.isPlural(date.min, "min");
+        var hours = this.isPlural(date.hours, "hour");
+        return $(this.el).html("" + date.years + " " + years + ", " + date.days + " "+ days +", " + (this.leadingZeros(date.hours)) + " " + hours + ", " + (this.leadingZeros(date.min)) + " " + min + " and " + (this.leadingZeros(date.sec)) + " sec");
       }
     };
     $.fn.countdown = function(options) {


### PR DESCRIPTION
Added logic to use the plural or singular form of the time (eg. day(s) or year(s)

Created a isPlural function that takes in the number and the string you
want it to output. It returns the string, either with or without an "s".

Now, if there is 1 day in the timer, it will say 1 day instead of 1
days. Same for years, hours, and minutes.
