### PR TITLE
Fix jquery dependency name conflict

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "examples/*"
   ],
   "dependencies": {
-    "jQuery": "^1.7.2"
+    "jquery": "^1.7.2"
   }
 }


### PR DESCRIPTION
jQuery should be referenced as `jquery` when installing with bower.