### PR TITLE
Specify `main` in Bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
   ],
   "dependencies": {
     "jQuery": "^1.7.2"
-  }
+  },
+  "main": [
+    "src/countdown.js"
+  ]
 }


### PR DESCRIPTION
Bower recommends that the `main` section of the manifest be specified to
indicate the primary files in the repository and the entry points for
consumers. Some Bower consumers require `main` in order to digest the
contents.